### PR TITLE
Dashboard: refresh list after contact submit

### DIFF
--- a/client/src/dashboard/ContactForm.jsx
+++ b/client/src/dashboard/ContactForm.jsx
@@ -68,6 +68,7 @@ export default class ContactForm extends Component {
             })
             .then(res => {
                 console.log("saved successfully")
+                this.props.onContactSubmitted();
             });
     }
 

--- a/client/src/dashboard/DashBoard.jsx
+++ b/client/src/dashboard/DashBoard.jsx
@@ -18,7 +18,8 @@ export default function withAuth(ComponentToProtect) {
             this.state = {
                 loading: true,
                 redirect: false,
-                contactFormToggle: false
+                contactFormToggle: false,
+                version: 0,
             };
         }
 
@@ -56,6 +57,15 @@ export default function withAuth(ComponentToProtect) {
         handleAddContactForm = event => {
             const {contactFormToggle} = this.state;
             this.setState({contactFormToggle: !contactFormToggle})
+        }
+
+        updateVersion = () => {
+            let version = this.state.version;
+            version++;
+
+            this.setState({
+                version: version
+            })
         }
 
         render() {
@@ -96,9 +106,9 @@ export default function withAuth(ComponentToProtect) {
 
                         </div>
 
-                        {this.state.contactFormToggle ? (<ContactForm></ContactForm>) : ""}
+                        {this.state.contactFormToggle ? (<ContactForm onContactSubmitted={this.updateVersion} />) : ""}
 
-                        <ListingComponent></ListingComponent>
+                        <ListingComponent key={`version_${this.state.version}`} />
 
 
                     </div>


### PR DESCRIPTION
By adding a version force a refresh of the contact component.
This will force a mount of the component refetching the list again.

closes #https://github.com/ferrycosv/corona-tracing-app/issues/48